### PR TITLE
Added preliminary support for converting between Itadaki Street Wii and Fortune Street

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@
 * `bsv2fsv` - Converts a Boom Street Virtual Address to Fortune Street.
 * `bsv2isv` - Converts a Boom Street Virtual Address to Itadaki Street Wii.
 * `fsv2bsv` - Converts a Fortune Street Virtual Address to Boom Street.
+* `fsv2isv` - Converts a Fortune Street Virtual Address to Itadaki Street Wii.
 * `isv2bsv` - Converts a Itadaki Street Wii Virtual Address to Boom Street.
+* `isv2fsv` - Converts a Itadaki Street Wii Virtual Address to Fortune Street.
 * `bsv2bsf` - Converts a Boom Street Virtual Address to Boom Street File Offset.
 * `fsv2fsf` - Converts a Fortune Street Virtual Address to Fortune Street File Offset.
 

--- a/commands/help/content/aliases.py
+++ b/commands/help/content/aliases.py
@@ -6,7 +6,9 @@ address_converter_aliases = [
     f"`{prefix}bsv2fsv` => `bsvtofsv` \n",
     f"`{prefix}bsv2isv` => `bsvtoisv` \n",
     f"`{prefix}fsv2bsv` => `fsvtobsv` \n",
+    f"`{prefix}fsv2isv` => `fsvtoisv` \n",
     f"`{prefix}isv2bsv` => `isvtobsv` \n",
+    f"`{prefix}isv2fsv` => `isvtofsv` \n",
     f"`{prefix}bsv2bsf` => `bsvtobsf` \n",
     f"`{prefix}fsv2fsf` => `fsvtofsf` \n",
 ]

--- a/commands/help/content/descriptions.py
+++ b/commands/help/content/descriptions.py
@@ -6,7 +6,9 @@ address_converters_help = [
     f"`{prefix}bsv2fsv` Boom Street Virtual Address to Fortune Street.\n",
     f"`{prefix}bsv2isv` Boom Street Virtual Address to Itadaki Street Wii.\n",
     f"`{prefix}fsv2bsv` Fortune Street Virtual Address to Boom Street.\n",
+    f"`{prefix}fsv2isv` Fortune Street Virtual Address to Itadaki Street Wii.\n",
     f"`{prefix}isv2bsv` Itadaki Street Wii Virtual Address to Boom Street.\n",
+    f"`{prefix}isv2fsv` Itadaki Street Wii Virtual Address to Fortune Street.\n",
     f"`{prefix}bsv2bsf` Boom Street Virtual Address to File Offset.\n",
     f"`{prefix}fsv2fsf` Fortune Street Virtual Address to File Offset.\n",
 ]


### PR DESCRIPTION
This required adding two new collections, which I built dynamically using the existing Boom-to-Other-Game dictionaries. I also added functions to allow direct conversion between Fortune Street and Itadaki Street Wii.

The benefit of this method is that if we determine later that there are inaccuracies in these offset maps, we'll only need to fix it in one place, rather than having two dictionaries per game to update.

This support is considered preliminary as the offset maps between Itadaki Street Wii and the other games has not been rigorously tested yet.